### PR TITLE
Manage the chloride gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Puppet toolkit for rapidly installing Puppet agents in Puppet Enterprise
 * [Overview](#overview)
 * [Module State](#module-state)
 * [Command Line Usage](#command-line-usage)
-* [Installation](#installation)
+* [Installation Requirements](#installation-requirements)
 * [Simple SSH agent deployment](#simple-ssh-agent-deployment)
   * [Simple SSH agent deployment with nodes file](#simple-ssh-agent-deployment-with-nodes-file)
   * [Simple SSH agent deployment with nodes STDIN](#simple-ssh-agent-deployment-with-nodes-stdin)
@@ -71,32 +71,31 @@ All possible CLI flags can be seen in the [Command Line Options](#command-line-o
 
 For Windows nodes, a separate method that uses a PowerShell script should be used. See [the docs here](#windows).
 
-## Installation
+## Installation Requirements
+
+### Chloride Gem
 
 The Puppet face requires the [chloride](https://rubygems.org/gems/chloride) gem to be in place in the Puppet ruby stack (not puppetserver)
 of the node that will be executing the Puppet face. This could be your Puppet master or some other Puppet agent that is able to connect
 to the soon-to-be Puppet agents.
 
-Install the gem manually with the following shell command:
+Install Chloride using one of these methods:
 
-```shell
-/opt/puppetlabs/puppet/bin/gem install chloride --no-ri --no-rdoc
-```
+* Automatically, with Puppet:
 
-> Future versions of Puppet Enterprise will likely ship with this gem see: [PE-17084](https://tickets.puppetlabs.com/browse/PE-17084)
+  ```puppet
+  include pe_bulk_agent_install::chloride
+  ```
 
-The gem can also be installed via Puppet with the following code:
+* Manually, into Puppet's Ruby stack:
 
-```puppet
-package {'chloride':
-  ensure   => 'present',
-  provider => 'puppet_gem',
-}
-```
+  ```shell
+  /opt/puppetlabs/puppet/bin/gem install chloride --no-ri --no-rdoc
+  ```
 
-> This should be incorporated into this module at a later date
+> Future versions of Puppet Enterprise (2017'ish) will likely ship with Chloride built-in to Puppet's Ruby stack on the master.
 
-### pe_repo Setup
+### pe_repo
 
 Because the Bulk Agent Installer face leverages the built-in Simplified Agent Installer of Puppet Enterprise, it's important that the
 simplified agent installer is setup accordingly. Namely, make sure that your Puppet master has the correct `pe_repo::platform` classes

--- a/manifests/chloride.pp
+++ b/manifests/chloride.pp
@@ -1,0 +1,17 @@
+# Manage the chloride gem for the PE Bulk Agent Install tool
+#
+# @param gem_provider The provider used to install the chloride gem.
+# @param gem_source The gem source to use when installing gems.
+#
+class pe_bulk_agent_install::chloride (
+  String           $gem_provider = 'puppet_gem',
+  Optional[String] $gem_source   = undef,
+) {
+
+  package {'chloride':
+    ensure   => 'present',
+    provider => $gem_provider,
+    source   => $gem_source,
+  }
+
+}

--- a/manifests/windows/master.pp
+++ b/manifests/windows/master.pp
@@ -11,9 +11,11 @@
 # ----------
 #
 # @param public_dir [String] The directory on the master to put the install.ps1 script. Defaults to '/opt/puppetlabs/server/data/packages/public'.
+# @param install_chloride [Boolean] Wether or not to manage the required gems (chloride). Defaults to true
 #
 class pe_bulk_agent_install::windows::master (
-  $public_dir = '/opt/puppetlabs/server/data/packages/public',
+  String  $public_dir       = '/opt/puppetlabs/server/data/packages/public',
+  Boolean $install_chloride = true,
 ) {
 
   validate_absolute_path($public_dir)
@@ -22,7 +24,7 @@ class pe_bulk_agent_install::windows::master (
   # We are wrapping this entire thing in an if ! defined() to prevent our version from being
   # used if pe_repo tries to make it.
   # This logic isn't fool proof because it's based on parse order, but it's close enough.
-  if ! defined(File["${public_dir}/${::pe_server_version}/install.ps1"]) {
+  if ! defined(File["${public_dir}/${$facts['pe_server_version']}/install.ps1"]) {
 
     require pe_repo
 
@@ -34,6 +36,10 @@ class pe_bulk_agent_install::windows::master (
       content => template("${module_name}/install.ps1.erb"),
     }
 
+  }
+
+  if $install_chloride {
+    include pe_bulk_agent_install::chloride
   }
 
 }

--- a/spec/classes/chloride_spec.rb
+++ b/spec/classes/chloride_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'pe_bulk_agent_install::chloride' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'when declared with all defaults' do
+        it { is_expected.to compile }
+
+        it { is_expected.to contain_package('chloride').with_ensure('present') }
+        it { is_expected.to contain_package('chloride').with_provider('puppet_gem') }
+        it { is_expected.to contain_package('chloride').with_source(nil) }
+      end
+    end
+  end
+end

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'pe_bulk_agent_install::windows::master' do
+  let(:pre_condition) { "class pe_repo( $master = 'puppet' ) {}" }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          pe_server_version: '2015.2.3',
+          settings: { masterport: '8140' }
+        )
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_class('pe_bulk_agent_install::chloride') }
+      end
+
+      context 'with install_chloride set to false' do
+        let(:params) do
+          {
+            install_chloride: false
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.not_to contain_class('pe_bulk_agent_install::chloride') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds a new class that installs the chloride gem.
* Install chloride by default in the windows::master class.
* Add spec tests for the new chloride class.

Resolves issue #5