### PR TITLE
Remove deprecated 'pe' requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,10 +12,6 @@
     {
       "name": "puppet",
       "version_requirement": ">=4.2.3 <5.0.0"
-    },
-    {
-      "name": "pe",
-      "versdion_requirement": ">=2015.2.3 <2017.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
The Forge no longer looks for or uses the 'pe' requirement in
metadata.json.

Prior to this, TravisCI builds were failing because metadata-lint was
throwing an error indicating the deprecation.