### PR TITLE
Fix the check for pre-existing install.ps1

### DIFF
--- a/manifests/windows/master.pp
+++ b/manifests/windows/master.pp
@@ -28,7 +28,7 @@ class pe_bulk_agent_install::windows::master (
   # We are wrapping this entire thing in an if ! defined() to prevent our version from being
   # used if pe_repo tries to make it.
   # This logic isn't fool proof because it's based on parse order, but it's close enough.
-  if ! defined(File["${public_dir}/${$facts['pe_server_version']}/install.ps1"]) {
+  if ! defined(File["${public_dir}/${facts['pe_server_version']}/install.ps1"]) {
 
     require pe_repo
 

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'pe_bulk_agent_install::windows::master' do
   let(:pre_condition) { "class pe_repo( $master = 'puppet' ) {}" }
 
-  context 'on a Puppet Enterprise master' do
+  context 'on a Puppet Enterprise master older than 2016.3' do
     let(:facts) do
       {
         pe_server_version: '2015.2.3',
@@ -19,6 +19,7 @@ describe 'pe_bulk_agent_install::windows::master' do
       it { is_expected.to contain_file('/opt/puppetlabs/server/data/packages/public/2015.2.3/install.ps1').with_content(%r{^\$port\s+=\s+'8140'$})  }
 
       it { is_expected.to contain_class('pe_bulk_agent_install::chloride') }
+      it { is_expected.to contain_class('pe_repo').that_comes_before('Class[pe_bulk_agent_install::windows::master]') }
     end
 
     context 'with install_chloride set to false' do
@@ -36,5 +37,21 @@ describe 'pe_bulk_agent_install::windows::master' do
 
   context 'on a non-Puppet Enterprise master' do
     it { is_expected.to raise_error(%r{should only be applied to a Puppet Master}) }
+  end
+
+  context 'on a Puppet Enterprise master that already has an install.ps1' do
+    let(:pre_condition) { "file { '/opt/puppetlabs/server/data/packages/public/2016.5.1/install.ps1': }" }
+
+    let(:facts) do
+      {
+        pe_server_version: '2016.5.1',
+        settings: { masterport: '8140' }
+      }
+    end
+
+    context 'with default parameters' do
+      it { is_expected.to compile }
+      it { is_expected.not_to contain_class('pe_repo') }
+    end
   end
 end


### PR DESCRIPTION
Prior to this, there was an extra `$` symbol in the if statement that
checks for an existing install.ps1. While the code still compiled and
worked, it's not the proper style to have the extra `$`.

Also added some spec tests to double-check that that if statement is
working and hopefully catch issues and regressions like this in the
future.