### PR TITLE
Issue #11: reassign target at the end of the while loop

### DIFF
--- a/lib/puppet/face/bulk.rb
+++ b/lib/puppet/face/bulk.rb
@@ -135,6 +135,7 @@ Puppet::Face.define(:bulk, '1.0.0') do
               Puppet.err("target:#{target} error:#{e}")
               mutex.synchronize { failed_nodes << Hash[target => e.to_s] }
             end
+            target = mutex.synchronize { nodes_thread.pop }
           end
         end
       end.each(&:join)


### PR DESCRIPTION
This fixes the behavior where the bulk agent installer loops endlessly after installing the agent. The `target` variable needs to be reassigned at the end of the while loop - it had previously been assigned in the while statement, so it got reassigned at the beginning of each iteration.